### PR TITLE
GH-3: Remove Statically Defined Extension Limitation

### DIFF
--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -96,14 +96,6 @@ interface RegisteredPlugin {
   fileTypes?: string[];
 }
 
-const DIRECT_FILE_URL_EXTS = new Set([
-  ".jpg", ".jpeg", ".png", ".gif", ".webp", ".svg", ".bmp", ".ico", ".avif", ".tiff",
-  ".mp4", ".m4v", ".webm", ".mov", ".mkv", ".avi", ".flv", ".wmv",
-  ".mp3", ".flac", ".wav", ".ogg", ".aac", ".wma", ".m4a",
-  ".pdf", ".zip", ".tar", ".gz", ".bz2", ".7z", ".rar", ".xz",
-  ".txt", ".md", ".json", ".xml", ".csv",
-]);
-
 export interface ViewProviderRegistration {
   pluginId: string;
   viewId: string;
@@ -731,7 +723,7 @@ export function getPluginForUrl(
 
     // Built-in Files fallback only makes sense for URLs that look like
     // direct file downloads, not arbitrary page URLs after a plugin removal.
-    if (g.__fallbackPlugin && ext && DIRECT_FILE_URL_EXTS.has(ext)) {
+    if (g.__fallbackPlugin && ext) {
       return {
         plugin: g.__fallbackPlugin.plugin,
         pluginId: g.__fallbackPlugin.pluginId,


### PR DESCRIPTION
### Fix: Allow custom extensions to fall back to Files plugin

Currently, downloads with extensions not included in `DIRECT_FILE_URL_EXTS` fail with:

```
No plugin found for URL
```

This prevents handling of valid file types such as `.zim` (e.g., from Kiwix archives), even when a Files plugin is configured to handle them.

### Root Cause

The registry enforces a strict extension check against `DIRECT_FILE_URL_EXTS`, which blocks resolution before reaching the Files plugin fallback.

### Change

* Modified plugin resolution logic to allow unknown extensions to fall back to the Files plugin when available

### Result

* Custom extensions (e.g., `.zim`) are now correctly routed to the Files plugin

### Notes

This enables workflows such as downloading Kiwix archives directly into a configured directory for external consumption.


fixes #3 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file handling to support any detected file extension, rather than a limited set of predefined types. The built-in file handler now activates more reliably for file URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->