### PR TITLE
Add NSFW file browser visibility controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Added
+- **Files** — NSFW marking for file browser items with a per-device Off/Blur/Show visibility setting, server-side hiding in SFW mode, and list/grid badges and blur states
 - **Files** — Search field in the standard file browser filters the current folder by file or folder name in list and grid views, with filtered counts and an empty-results state
 - **FlareSolverr** — Core settings action "Test FlareSolverr" and `POST /api/settings/flaresolverr-test` to verify connectivity (optional JSON `baseUrl` overrides the saved URL); `helpers.flaresolverr.testConnection()` and `fetchCookiesForUrl()` for plugins
 - **Docker Compose** — Optional `flaresolverr` service (`docker compose --profile flaresolverr up -d`) on port 8191 for local bypass testing

--- a/drizzle/0005_premium_random.sql
+++ b/drizzle/0005_premium_random.sql
@@ -1,0 +1,6 @@
+CREATE TABLE `file_metadata` (
+	`path` text PRIMARY KEY NOT NULL,
+	`is_nsfw` integer DEFAULT false NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,429 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a2cc5125-eb4f-4f94-ba9e-c1054aea93db",
+  "prevId": "49116f50-ad11-4987-bebb-7a2158731f63",
+  "tables": {
+    "download_history": {
+      "name": "download_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_name": {
+          "name": "plugin_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "download_queue": {
+      "name": "download_queue",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "plugin_name": {
+          "name": "plugin_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "file_metadata": {
+      "name": "file_metadata",
+      "columns": {
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_nsfw": {
+          "name": "is_nsfw",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "installed_plugins": {
+      "name": "installed_plugins",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'1.0.0'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url_patterns": {
+          "name": "url_patterns",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_types": {
+          "name": "file_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "has_settings": {
+          "name": "has_settings",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_urls": {
+      "name": "scheduled_urls",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_value": {
+          "name": "default_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation": {
+          "name": "validation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1775188174443,
       "tag": "0004_square_kitty_pryde",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1781020616928,
+      "tag": "0005_premium_random",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/files/metadata/route.ts
+++ b/src/app/api/files/metadata/route.ts
@@ -2,6 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import fs from "fs/promises";
 import path from "path";
 import { resolveSafePath, getRelativePath, FileError } from "@/lib/files";
+import {
+  NSFW_MODE_SETTING_KEY,
+  getNsfwMetadataRows,
+  getNsfwState,
+  normalizeNsfwMode,
+} from "@/lib/file-metadata";
+import { getSetting } from "@/lib/settings";
 
 export const dynamic = "force-dynamic";
 
@@ -104,15 +111,25 @@ function mediaUrl(filePath: string, root: string): string {
 async function findMedia(
   dirPath: string,
   root: string,
-  max: number
+  max: number,
+  shouldHideNsfw: boolean,
+  nsfwRows: ReturnType<typeof getNsfwMetadataRows>
 ): Promise<string[]> {
   try {
     const entries: import("fs").Dirent[] = await fs.readdir(dirPath, { withFileTypes: true });
     const urls: string[] = [];
     for (const entry of entries) {
       if (entry.name.startsWith(".")) continue;
+      const childPath = path.join(dirPath, entry.name);
+      const relativeChildPath = getRelativePath(childPath, root);
+      if (
+        shouldHideNsfw &&
+        getNsfwState(relativeChildPath, nsfwRows).isNsfw
+      ) {
+        continue;
+      }
       if (!entry.isDirectory() && MEDIA_RE.test(entry.name)) {
-        urls.push(mediaUrl(path.join(dirPath, entry.name), root));
+        urls.push(mediaUrl(childPath, root));
         if (urls.length >= max) break;
       }
     }
@@ -126,7 +143,9 @@ async function findMedia(
 async function buildPreview(
   absolute: string,
   root: string,
-  post: PostCardMetadata | null
+  post: PostCardMetadata | null,
+  shouldHideNsfw: boolean,
+  nsfwRows: ReturnType<typeof getNsfwMetadataRows>
 ): Promise<{ preview: FolderPreview; itemCount: number }> {
   let entries: import("fs").Dirent[];
   try {
@@ -135,7 +154,11 @@ async function buildPreview(
     return { preview: { type: "empty" }, itemCount: 0 };
   }
 
-  const visible = entries.filter((e) => !e.name.startsWith("."));
+  const visible = entries.filter((entry) => {
+    if (entry.name.startsWith(".")) return false;
+    const relativeEntryPath = getRelativePath(path.join(absolute, entry.name), root);
+    return !shouldHideNsfw || !getNsfwState(relativeEntryPath, nsfwRows).isNsfw;
+  });
   const dirs = visible.filter((e) => e.isDirectory());
   const files = visible.filter((e) => !e.isDirectory());
   const itemCount = visible.length;
@@ -158,7 +181,9 @@ async function buildPreview(
       const found = await findMedia(
         childPath,
         root,
-        MAX_PREVIEW_IMAGES - collageMedia.length
+        MAX_PREVIEW_IMAGES - collageMedia.length,
+        shouldHideNsfw,
+        nsfwRows
       );
       collageMedia.push(...found);
       if (collageMedia.length >= MAX_PREVIEW_IMAGES) break;
@@ -203,19 +228,42 @@ export async function GET(request: NextRequest) {
   try {
     const relativePath = request.nextUrl.searchParams.get("path") || "";
     const { absolute, root } = resolveSafePath(relativePath);
+    const nsfwMode = normalizeNsfwMode(
+      getSetting<string>(NSFW_MODE_SETTING_KEY)
+    );
+    const shouldHideNsfw = nsfwMode === "off";
+    const nsfwRows = getNsfwMetadataRows();
+    if (shouldHideNsfw && getNsfwState(relativePath, nsfwRows).isNsfw) {
+      return NextResponse.json({
+        preview: { type: "empty" },
+        itemCount: 0,
+      } satisfies FolderCardMetadata);
+    }
 
     // Read Post.nfo if it exists
     let post: PostCardMetadata | null = null;
     const nfoPath = path.join(absolute, "Post.nfo");
     try {
-      const content = await fs.readFile(nfoPath, "utf-8");
-      post = parseNfo(content);
+      const nfoRelativePath = getRelativePath(nfoPath, root);
+      if (
+        !shouldHideNsfw ||
+        !getNsfwState(nfoRelativePath, nsfwRows).isNsfw
+      ) {
+        const content = await fs.readFile(nfoPath, "utf-8");
+        post = parseNfo(content);
+      }
     } catch {
       // No Post.nfo — that's fine
     }
 
     // Build preview
-    const { preview, itemCount } = await buildPreview(absolute, root, post);
+    const { preview, itemCount } = await buildPreview(
+      absolute,
+      root,
+      post,
+      shouldHideNsfw,
+      nsfwRows
+    );
 
     const result: FolderCardMetadata = {
       preview,

--- a/src/app/api/files/nsfw/route.ts
+++ b/src/app/api/files/nsfw/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  getRelativePath,
+  resolveSafePath,
+  FileError,
+} from "@/lib/files";
+import { setExplicitNsfw } from "@/lib/file-metadata";
+
+export const dynamic = "force-dynamic";
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const paths: string[] = Array.isArray(body.paths)
+      ? body.paths
+      : body.path
+        ? [body.path]
+        : [];
+    const isNsfw = body.isNsfw;
+
+    if (paths.length === 0 || typeof isNsfw !== "boolean") {
+      return NextResponse.json(
+        { error: "paths and isNsfw are required" },
+        { status: 400 }
+      );
+    }
+
+    const safePaths: string[] = [];
+    for (const relativePath of paths) {
+      const { absolute, root } = resolveSafePath(relativePath);
+      if (absolute === root) {
+        return NextResponse.json(
+          { error: "Cannot mark the root download directory" },
+          { status: 403 }
+        );
+      }
+      safePaths.push(getRelativePath(absolute, root));
+    }
+
+    setExplicitNsfw(safePaths, isNsfw);
+
+    return NextResponse.json({
+      success: true,
+      updated: safePaths.length,
+      isNsfw,
+    });
+  } catch (err) {
+    if (err instanceof FileError) {
+      const status =
+        err.code === "TRAVERSAL"
+          ? 403
+          : err.code === "NOT_FOUND"
+            ? 404
+            : 400;
+      return NextResponse.json({ error: err.message }, { status });
+    }
+    console.error("Error updating NSFW metadata:", err);
+    return NextResponse.json(
+      { error: "Failed to update NSFW metadata" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/files/route.ts
+++ b/src/app/api/files/route.ts
@@ -7,6 +7,17 @@ import {
   getRelativePath,
   FileError,
 } from "@/lib/files";
+import {
+  NSFW_MODE_SETTING_KEY,
+  copyNsfwMetadata,
+  deleteNsfwMetadata,
+  getNsfwMetadataRows,
+  getNsfwState,
+  moveNsfwMetadata,
+  normalizeNsfwMode,
+  setExplicitNsfw,
+} from "@/lib/file-metadata";
+import { getSetting } from "@/lib/settings";
 
 export const dynamic = "force-dynamic";
 
@@ -16,6 +27,8 @@ export interface FileEntry {
   isDirectory: boolean;
   size: number;
   modifiedAt: string;
+  isNsfw: boolean;
+  isNsfwExplicit: boolean;
 }
 
 export async function GET(request: NextRequest) {
@@ -33,6 +46,10 @@ export async function GET(request: NextRequest) {
 
     const entries = await fs.readdir(absolute, { withFileTypes: true });
     const results: FileEntry[] = [];
+    const nsfwMode = normalizeNsfwMode(
+      getSetting<string>(NSFW_MODE_SETTING_KEY)
+    );
+    const nsfwRows = getNsfwMetadataRows();
 
     for (const entry of entries) {
       // Skip hidden files
@@ -41,12 +58,18 @@ export async function GET(request: NextRequest) {
       const entryPath = path.join(absolute, entry.name);
       try {
         const entryStat = await fs.stat(entryPath);
+        const relativeEntryPath = getRelativePath(entryPath, root);
+        const nsfwState = getNsfwState(relativeEntryPath, nsfwRows);
+        if (nsfwMode === "off" && nsfwState.isNsfw) continue;
+
         results.push({
           name: entry.name,
-          path: getRelativePath(entryPath, root),
+          path: relativeEntryPath,
           isDirectory: entry.isDirectory(),
           size: entry.isDirectory() ? 0 : entryStat.size,
           modifiedAt: entryStat.mtime.toISOString(),
+          isNsfw: nsfwState.isNsfw,
+          isNsfwExplicit: nsfwState.isNsfwExplicit,
         });
       } catch {
         // Skip entries we can't stat (broken symlinks, permission issues)
@@ -137,17 +160,23 @@ export async function PATCH(request: NextRequest) {
       );
     }
 
-    const { absolute: sourceAbsolute, root } = resolveSafePath(sourcePath);
+    const { absolute: sourceAbsolute } = resolveSafePath(sourcePath);
     const parentDir = path.dirname(sourcePath);
-    const newRelativePath = parentDir ? `${parentDir}/${newName}` : newName;
-    const { absolute: targetAbsolute } = resolveSafeNewPath(newRelativePath);
+    const normalizedParentDir = parentDir === "." ? "" : parentDir;
+    const nextRelativePath = normalizedParentDir
+      ? `${normalizedParentDir}/${newName}`
+      : newName;
+    const { absolute: targetAbsolute } = resolveSafeNewPath(nextRelativePath);
 
+    const sourceNsfwState = getNsfwState(sourcePath);
     await fs.rename(sourceAbsolute, targetAbsolute);
+    moveNsfwMetadata(sourcePath, nextRelativePath);
+    preserveNsfwStateAfterMoveOrCopy(sourceNsfwState.isNsfw, nextRelativePath);
 
     return NextResponse.json({
       success: true,
       oldPath: sourcePath,
-      newPath: newRelativePath,
+      newPath: nextRelativePath,
     });
   } catch (err) {
     if (err instanceof FileError) {
@@ -202,9 +231,13 @@ export async function PUT(request: NextRequest) {
 
     const completed: string[] = [];
     for (const sourcePath of paths) {
-      const { absolute: sourceAbsolute, root } = resolveSafePath(sourcePath);
+      const { absolute: sourceAbsolute } = resolveSafePath(sourcePath);
       const basename = path.basename(sourceAbsolute);
       const targetAbsolute = path.join(destAbsolute, basename);
+      const targetRelativePath = destination
+        ? `${destination}/${basename}`
+        : basename;
+      const sourceNsfwState = getNsfwState(sourcePath);
 
       // Containment check — prevent moving folder into itself or descendant
       const realSource = await fs.realpath(sourceAbsolute);
@@ -239,9 +272,15 @@ export async function PUT(request: NextRequest) {
 
       if (action === "move") {
         await fs.rename(sourceAbsolute, targetAbsolute);
+        moveNsfwMetadata(sourcePath, targetRelativePath);
       } else {
         await fs.cp(sourceAbsolute, targetAbsolute, { recursive: true });
+        copyNsfwMetadata(sourcePath, targetRelativePath);
       }
+      preserveNsfwStateAfterMoveOrCopy(
+        sourceNsfwState.isNsfw,
+        targetRelativePath
+      );
       completed.push(sourcePath);
     }
 
@@ -269,6 +308,14 @@ export async function PUT(request: NextRequest) {
   }
 }
 
+function preserveNsfwStateAfterMoveOrCopy(
+  sourceWasNsfw: boolean,
+  targetPath: string
+) {
+  if (!sourceWasNsfw || getNsfwState(targetPath).isNsfw) return;
+  setExplicitNsfw([targetPath], true);
+}
+
 export async function DELETE(request: NextRequest) {
   try {
     const body = await request.json();
@@ -293,6 +340,7 @@ export async function DELETE(request: NextRequest) {
       }
 
       await fs.rm(absolute, { recursive: true, force: true });
+      deleteNsfwMetadata(relativePath);
       deleted.push(relativePath);
     }
 

--- a/src/app/files/page.tsx
+++ b/src/app/files/page.tsx
@@ -11,6 +11,8 @@ import {
 import { FileBreadcrumb } from "@/components/files/file-breadcrumb";
 import type { FileEntry } from "@/lib/types";
 
+type NsfwMode = "off" | "blur" | "show";
+
 function getPathFromUrl(): string {
   if (typeof window === "undefined") return "";
   const params = new URLSearchParams(window.location.search);
@@ -33,6 +35,7 @@ export default function FilesPage() {
   const [userExplicitlySelectedFiles, setUserExplicitlySelectedFiles] = useState(false);
   const [previewFile, setPreviewFile] = useState<FileEntry | null>(null);
   const [mounted, setMounted] = useState(false);
+  const [nsfwMode, setNsfwMode] = useState<NsfwMode>("off");
 
 
   const fetchFiles = useCallback(async (filePath: string) => {
@@ -51,6 +54,25 @@ export default function FilesPage() {
       setFiles([]);
     } finally {
       setLoading(false);
+    }
+  }, []);
+
+  const fetchNsfwMode = useCallback(async () => {
+    try {
+      const res = await fetch("/api/settings");
+      if (!res.ok) return;
+      const data = await res.json();
+      const coreSettings = data.groups?.core ?? [];
+      const setting = coreSettings.find(
+        (item: { key: string }) => item.key === "core.nsfw_mode"
+      );
+      setNsfwMode(
+        setting?.value === "blur" || setting?.value === "show"
+          ? setting.value
+          : "off"
+      );
+    } catch {
+      setNsfwMode("off");
     }
   }, []);
 
@@ -122,6 +144,7 @@ export default function FilesPage() {
       // After files load, check if this is a post directory (contains Post.nfo)
       // If so, auto-activate plugin view for the detail renderer
     });
+    fetchNsfwMode();
     fetchViewProviders(currentPath).then((providers) => {
       if (providers.length === 0) {
         setActiveProviderId(null);
@@ -141,7 +164,7 @@ export default function FilesPage() {
         }
       }
     });
-  }, [mounted, currentPath, fetchFiles, fetchViewProviders, userExplicitlySelectedFiles]);
+  }, [mounted, currentPath, fetchFiles, fetchNsfwMode, fetchViewProviders, userExplicitlySelectedFiles]);
 
   // Auto-activate plugin view when entering a post directory (has Post.nfo)
   useEffect(() => {
@@ -160,6 +183,7 @@ export default function FilesPage() {
   }, []);
 
   function handleRefresh() {
+    fetchNsfwMode();
     fetchFiles(currentPath);
   }
 
@@ -298,6 +322,7 @@ export default function FilesPage() {
             onNavigate={handleNavigate}
             onRefresh={handleRefresh}
             onFileOpen={handleFileOpen}
+            nsfwMode={nsfwMode}
           />
         </div>
       )}

--- a/src/components/files/file-browser.tsx
+++ b/src/components/files/file-browser.tsx
@@ -18,6 +18,7 @@ import {
   LayoutGrid,
   Search,
   X,
+  ShieldAlert,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -56,6 +57,7 @@ interface FileBrowserProps {
   files: FileEntry[];
   currentPath: string;
   loading: boolean;
+  nsfwMode: "off" | "blur" | "show";
   onNavigate: (path: string) => void;
   onRefresh: () => void;
   onFileOpen?: (file: FileEntry) => void;
@@ -65,6 +67,7 @@ export function FileBrowser({
   files,
   currentPath,
   loading,
+  nsfwMode,
   onNavigate,
   onRefresh,
   onFileOpen,
@@ -87,6 +90,7 @@ export function FileBrowser({
     action: "move" | "copy";
   } | null>(null);
   const [batchDeleting, setBatchDeleting] = useState(false);
+  const [batchUpdatingNsfw, setBatchUpdatingNsfw] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
 
   const hasSelection = selectedPaths.size > 0;
@@ -254,6 +258,45 @@ export function FileBrowser({
     }
   }, [selectedPaths, onRefresh]);
 
+  const handleNsfwUpdate = useCallback(
+    async (paths: string[], isNsfw: boolean) => {
+      if (paths.length === 0) return;
+      try {
+        const res = await fetch("/api/files/nsfw", {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ paths, isNsfw }),
+        });
+        if (res.ok) {
+          toast.success(
+            `${isNsfw ? "Marked" : "Unmarked"} ${paths.length} item${paths.length !== 1 ? "s" : ""} as NSFW`
+          );
+          onRefresh();
+        } else {
+          const data = await res.json();
+          toast.error(data.error || "Failed to update NSFW state");
+        }
+      } catch {
+        toast.error("Failed to update NSFW state");
+      }
+    },
+    [onRefresh]
+  );
+
+  const handleBatchNsfwUpdate = useCallback(
+    async (isNsfw: boolean) => {
+      if (selectedPaths.size === 0) return;
+      setBatchUpdatingNsfw(true);
+      try {
+        await handleNsfwUpdate(Array.from(selectedPaths), isNsfw);
+        setSelectedPaths(new Set());
+      } finally {
+        setBatchUpdatingNsfw(false);
+      }
+    },
+    [handleNsfwUpdate, selectedPaths]
+  );
+
   return (
     <>
       <Card className="overflow-hidden border-border/50">
@@ -393,6 +436,9 @@ export function FileBrowser({
             }
             onDownloadZip={handleDownloadZip}
             onDelete={handleBatchDelete}
+            onMarkNsfw={() => handleBatchNsfwUpdate(true)}
+            onUnmarkNsfw={() => handleBatchNsfwUpdate(false)}
+            updatingNsfw={batchUpdatingNsfw}
             onClear={() => setSelectedPaths(new Set())}
           />
         )}
@@ -440,6 +486,8 @@ export function FileBrowser({
               onRename={(file) => setRenameTarget(file)}
               onMoveCopy={(paths, action) => setMoveCopyAction({ paths, action })}
               onDelete={(path) => handleDelete(path)}
+              onNsfwUpdate={(path, isNsfw) => handleNsfwUpdate([path], isNsfw)}
+              nsfwMode={nsfwMode}
             />
           ) : (
             <div className="divide-y divide-border/50">
@@ -491,12 +539,15 @@ export function FileBrowser({
                   ? Folder
                   : FILE_ICONS[getFileIconType(file.name)] || File;
                 const isSelected = selectedPaths.has(file.path);
+                const shouldBlur = nsfwMode === "blur" && file.isNsfw;
+                const shouldBadge =
+                  file.isNsfw && (nsfwMode === "blur" || nsfwMode === "show");
 
                 return (
                   <div
                     key={file.path}
                     className={cn(
-                      "group flex items-center gap-4 px-5 py-3.5 transition-colors animate-vault-enter cursor-pointer",
+                      "group/nsfw group flex items-center gap-4 px-5 py-3.5 transition-colors animate-vault-enter cursor-pointer",
                       isSelected
                         ? "bg-primary/5"
                         : "hover:bg-muted/30"
@@ -538,7 +589,9 @@ export function FileBrowser({
                         "flex size-8 shrink-0 items-center justify-center rounded-lg transition-colors",
                         file.isDirectory
                           ? "bg-primary/10 text-primary"
-                          : "bg-muted text-muted-foreground"
+                          : "bg-muted text-muted-foreground",
+                        shouldBlur &&
+                          "blur-sm group-hover/nsfw:blur-0 group-focus-within/nsfw:blur-0"
                       )}
                     >
                       <IconComponent className="size-4" />
@@ -546,16 +599,29 @@ export function FileBrowser({
 
                     {/* Name */}
                     <div className="flex-1 min-w-0">
-                      <p
-                        className={cn(
-                          "text-sm truncate",
-                          file.isDirectory
-                            ? "font-medium"
-                            : "text-muted-foreground"
+                      <div className="flex min-w-0 items-center gap-2">
+                        <p
+                          className={cn(
+                            "text-sm truncate",
+                            file.isDirectory
+                              ? "font-medium"
+                              : "text-muted-foreground",
+                            shouldBlur &&
+                              "blur-sm group-hover/nsfw:blur-0 group-focus-within/nsfw:blur-0"
+                          )}
+                        >
+                          {file.name}
+                        </p>
+                        {shouldBadge && (
+                          <Badge
+                            variant="destructive"
+                            className="shrink-0 gap-1 px-1.5 py-0 text-[10px]"
+                          >
+                            <ShieldAlert className="size-3" />
+                            NSFW
+                          </Badge>
                         )}
-                      >
-                        {file.name}
-                      </p>
+                      </div>
                     </div>
 
                     {/* Size */}
@@ -646,6 +712,16 @@ export function FileBrowser({
                           >
                             <Copy className="size-4" />
                             Copy to...
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            className="gap-2"
+                            onSelect={() =>
+                              handleNsfwUpdate([file.path], !file.isNsfwExplicit)
+                            }
+                          >
+                            <ShieldAlert className="size-4" />
+                            {file.isNsfwExplicit ? "Unmark NSFW" : "Mark NSFW"}
                           </DropdownMenuItem>
                           <DropdownMenuSeparator />
                           <DropdownMenuItem

--- a/src/components/files/file-grid-view.tsx
+++ b/src/components/files/file-grid-view.tsx
@@ -14,6 +14,8 @@ interface FileGridViewProps {
   onRename: (file: FileEntry) => void;
   onMoveCopy: (paths: string[], action: "move" | "copy") => void;
   onDelete: (path: string) => void;
+  onNsfwUpdate: (path: string, isNsfw: boolean) => void;
+  nsfwMode: "off" | "blur" | "show";
 }
 
 export function FileGridView({
@@ -27,6 +29,8 @@ export function FileGridView({
   onRename,
   onMoveCopy,
   onDelete,
+  onNsfwUpdate,
+  nsfwMode,
 }: FileGridViewProps) {
   return (
     <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-4 p-4">
@@ -46,6 +50,8 @@ export function FileGridView({
           onRename={onRename}
           onMoveCopy={onMoveCopy}
           onDelete={onDelete}
+          onNsfwUpdate={onNsfwUpdate}
+          nsfwMode={nsfwMode}
         />
       ))}
     </div>

--- a/src/components/files/file-selection-toolbar.tsx
+++ b/src/components/files/file-selection-toolbar.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { FolderInput, Copy, Download, Trash2, X } from "lucide-react";
+import {
+  FolderInput,
+  Copy,
+  Download,
+  Trash2,
+  X,
+  ShieldAlert,
+} from "lucide-react";
 
 interface FileSelectionToolbarProps {
   selectedCount: number;
@@ -9,6 +16,9 @@ interface FileSelectionToolbarProps {
   onCopy: () => void;
   onDownloadZip: () => void;
   onDelete: () => void;
+  onMarkNsfw: () => void;
+  onUnmarkNsfw: () => void;
+  updatingNsfw?: boolean;
   onClear: () => void;
 }
 
@@ -18,6 +28,9 @@ export function FileSelectionToolbar({
   onCopy,
   onDownloadZip,
   onDelete,
+  onMarkNsfw,
+  onUnmarkNsfw,
+  updatingNsfw = false,
   onClear,
 }: FileSelectionToolbarProps) {
   return (
@@ -56,6 +69,26 @@ export function FileSelectionToolbar({
         >
           <Download className="size-3.5" />
           Download Zip
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-9 gap-1.5 text-xs text-destructive hover:text-destructive hover:bg-destructive/10 sm:h-7"
+          disabled={updatingNsfw}
+          onClick={onMarkNsfw}
+        >
+          <ShieldAlert className="size-3.5" />
+          Mark NSFW
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-9 gap-1.5 text-xs sm:h-7"
+          disabled={updatingNsfw}
+          onClick={onUnmarkNsfw}
+        >
+          <ShieldAlert className="size-3.5" />
+          Unmark NSFW
         </Button>
         <Button
           variant="ghost"

--- a/src/components/files/grid/file-card.tsx
+++ b/src/components/files/grid/file-card.tsx
@@ -8,9 +8,11 @@ import {
   FolderInput,
   Copy,
   MoreHorizontal,
+  ShieldAlert,
 } from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -35,6 +37,8 @@ interface FileCardProps {
   onRename: (file: FileEntry) => void;
   onMoveCopy: (paths: string[], action: "move" | "copy") => void;
   onDelete: (path: string) => void;
+  onNsfwUpdate: (path: string, isNsfw: boolean) => void;
+  nsfwMode: "off" | "blur" | "show";
 }
 
 export function FileCard({
@@ -47,15 +51,20 @@ export function FileCard({
   onRename,
   onMoveCopy,
   onDelete,
+  onNsfwUpdate,
+  nsfwMode,
 }: FileCardProps) {
   const cardData = useFolderCardData(file.isDirectory ? file.path : "");
   const post = cardData?.post;
   const displayName = post ? post.title : file.name;
+  const shouldBlur = nsfwMode === "blur" && file.isNsfw;
+  const shouldBadge =
+    file.isNsfw && (nsfwMode === "blur" || nsfwMode === "show");
 
   return (
     <div
       className={cn(
-        "group relative rounded-xl border overflow-hidden cursor-pointer transition-all animate-vault-enter",
+        "group/nsfw group relative rounded-xl border overflow-hidden cursor-pointer transition-all animate-vault-enter",
         isSelected
           ? "border-primary ring-2 ring-primary/20 bg-card"
           : "border-border/50 bg-card hover:border-primary/50 hover:shadow-sm"
@@ -65,10 +74,28 @@ export function FileCard({
     >
       {/* Thumbnail */}
       <div className="aspect-[16/10] bg-muted relative overflow-hidden">
-        {file.isDirectory ? (
-          <FolderThumbnail preview={cardData?.preview} />
-        ) : (
-          <FileThumbnail file={file} />
+        <div
+          className={cn(
+            "h-full w-full transition-[filter]",
+            shouldBlur &&
+              "blur-md group-hover/nsfw:blur-0 group-focus-within/nsfw:blur-0"
+          )}
+        >
+          {file.isDirectory ? (
+            <FolderThumbnail preview={cardData?.preview} />
+          ) : (
+            <FileThumbnail file={file} />
+          )}
+        </div>
+
+        {shouldBadge && (
+          <Badge
+            variant="destructive"
+            className="absolute bottom-2 left-2 z-10 gap-1 px-1.5 py-0 text-[10px]"
+          >
+            <ShieldAlert className="size-3" />
+            NSFW
+          </Badge>
         )}
 
         {/* Checkbox overlay */}
@@ -160,6 +187,16 @@ export function FileCard({
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem
+                className="gap-2"
+                onSelect={() =>
+                  onNsfwUpdate(file.path, !file.isNsfwExplicit)
+                }
+              >
+                <ShieldAlert className="size-4" />
+                {file.isNsfwExplicit ? "Unmark NSFW" : "Mark NSFW"}
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
                 className="gap-2 text-destructive focus:text-destructive focus:bg-destructive/10"
                 onSelect={() => onDelete(file.path)}
               >
@@ -172,7 +209,13 @@ export function FileCard({
       </div>
 
       {/* Body */}
-      <div className="p-3">
+      <div
+        className={cn(
+          "p-3 transition-[filter]",
+          shouldBlur &&
+            "blur-sm group-hover/nsfw:blur-0 group-focus-within/nsfw:blur-0"
+        )}
+      >
         <p
           className={cn(
             "text-sm truncate",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -17,6 +17,17 @@ export const settings = sqliteTable("settings", {
     .$defaultFn(() => new Date()),
 });
 
+export const fileMetadata = sqliteTable("file_metadata", {
+  path: text("path").primaryKey(),
+  isNsfw: integer("is_nsfw", { mode: "boolean" }).notNull().default(false),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+
 export const installedPlugins = sqliteTable("installed_plugins", {
   id: text("id").primaryKey(),
   name: text("name").notNull(),

--- a/src/lib/file-metadata.ts
+++ b/src/lib/file-metadata.ts
@@ -1,0 +1,163 @@
+import { getDb, schema } from "@/db";
+import { eq } from "drizzle-orm";
+
+export type NsfwMode = "off" | "blur" | "show";
+
+export const NSFW_MODE_SETTING_KEY = "core.nsfw_mode";
+
+export interface FileNsfwState {
+  isNsfw: boolean;
+  isNsfwExplicit: boolean;
+}
+
+interface NsfwMetadataRow {
+  path: string;
+  isNsfw: boolean;
+}
+
+export function normalizeRelativeFilePath(filePath: string): string {
+  const normalized = filePath.replace(/\\/g, "/").replace(/^\/+|\/+$/g, "");
+  return normalized
+    .split("/")
+    .filter(Boolean)
+    .join("/");
+}
+
+export function normalizeNsfwMode(value: unknown): NsfwMode {
+  return value === "blur" || value === "show" ? value : "off";
+}
+
+export function getNsfwMetadataRows(): NsfwMetadataRow[] {
+  return getDb()
+    .select({
+      path: schema.fileMetadata.path,
+      isNsfw: schema.fileMetadata.isNsfw,
+    })
+    .from(schema.fileMetadata)
+    .where(eq(schema.fileMetadata.isNsfw, true))
+    .all()
+    .map((row) => ({
+      path: normalizeRelativeFilePath(row.path),
+      isNsfw: row.isNsfw,
+    }));
+}
+
+export function getNsfwState(
+  filePath: string,
+  rows: NsfwMetadataRow[] = getNsfwMetadataRows()
+): FileNsfwState {
+  const normalized = normalizeRelativeFilePath(filePath);
+  const isNsfwExplicit = rows.some((row) => row.path === normalized);
+  const isNsfwInherited = rows.some(
+    (row) => row.path !== normalized && isSameOrDescendant(normalized, row.path)
+  );
+
+  return {
+    isNsfw: isNsfwExplicit || isNsfwInherited,
+    isNsfwExplicit,
+  };
+}
+
+export function setExplicitNsfw(paths: string[], isNsfw: boolean): void {
+  const db = getDb();
+  const now = new Date();
+  const normalizedPaths = Array.from(
+    new Set(paths.map(normalizeRelativeFilePath).filter(Boolean))
+  );
+
+  for (const filePath of normalizedPaths) {
+    if (isNsfw) {
+      db.insert(schema.fileMetadata)
+        .values({
+          path: filePath,
+          isNsfw: true,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .onConflictDoUpdate({
+          target: schema.fileMetadata.path,
+          set: { isNsfw: true, updatedAt: now },
+        })
+        .run();
+    } else {
+      db.delete(schema.fileMetadata)
+        .where(eq(schema.fileMetadata.path, filePath))
+        .run();
+    }
+  }
+}
+
+export function moveNsfwMetadata(sourcePath: string, targetPath: string): void {
+  const source = normalizeRelativeFilePath(sourcePath);
+  const target = normalizeRelativeFilePath(targetPath);
+  if (!source || !target) return;
+
+  const rows = matchingRows(source);
+  deleteNsfwMetadata(target);
+
+  for (const row of rows) {
+    const nextPath = replacePathPrefix(row.path, source, target);
+    getDb()
+      .update(schema.fileMetadata)
+      .set({ path: nextPath, updatedAt: new Date() })
+      .where(eq(schema.fileMetadata.path, row.path))
+      .run();
+  }
+}
+
+export function copyNsfwMetadata(sourcePath: string, targetPath: string): void {
+  const source = normalizeRelativeFilePath(sourcePath);
+  const target = normalizeRelativeFilePath(targetPath);
+  if (!source || !target) return;
+
+  const rows = matchingRows(source);
+  const now = new Date();
+
+  for (const row of rows) {
+    const nextPath = replacePathPrefix(row.path, source, target);
+    getDb()
+      .insert(schema.fileMetadata)
+      .values({
+        path: nextPath,
+        isNsfw: row.isNsfw,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: schema.fileMetadata.path,
+        set: { isNsfw: row.isNsfw, updatedAt: now },
+      })
+      .run();
+  }
+}
+
+export function deleteNsfwMetadata(sourcePath: string): void {
+  const source = normalizeRelativeFilePath(sourcePath);
+  if (!source) return;
+
+  for (const row of matchingRows(source)) {
+    getDb()
+      .delete(schema.fileMetadata)
+      .where(eq(schema.fileMetadata.path, row.path))
+      .run();
+  }
+}
+
+function matchingRows(sourcePath: string): NsfwMetadataRow[] {
+  return getNsfwMetadataRows().filter((row) =>
+    isSameOrDescendant(row.path, sourcePath)
+  );
+}
+
+function isSameOrDescendant(filePath: string, ancestorPath: string): boolean {
+  return filePath === ancestorPath || filePath.startsWith(`${ancestorPath}/`);
+}
+
+function replacePathPrefix(
+  filePath: string,
+  sourcePath: string,
+  targetPath: string
+): string {
+  const suffix = filePath.slice(sourcePath.length);
+  return `${targetPath}${suffix}`;
+}

--- a/src/lib/settings-defs.ts
+++ b/src/lib/settings-defs.ts
@@ -24,6 +24,24 @@ export const CORE_SETTINGS: SettingDefinition[] = [
     sortOrder: 1,
   },
   {
+    key: "core.nsfw_mode",
+    group: "core",
+    type: "select",
+    label: "NSFW Content Visibility",
+    description:
+      "Controls how file browser items marked NSFW are handled on this device.",
+    defaultValue: "off",
+    validation: {
+      required: true,
+      options: [
+        { label: "Off - hide NSFW items", value: "off" },
+        { label: "Blur - obscure until hover", value: "blur" },
+        { label: "Show - display with badge", value: "show" },
+      ],
+    },
+    sortOrder: 2,
+  },
+  {
     key: "core.flaresolverr_url",
     group: "core",
     type: "string",
@@ -32,7 +50,7 @@ export const CORE_SETTINGS: SettingDefinition[] = [
       "URL of a FlareSolverr instance for bypassing Cloudflare (e.g., http://flaresolverr:8191). Leave empty to disable.",
     defaultValue: "",
     envVar: "FLARESOLVERR_URL",
-    sortOrder: 2,
+    sortOrder: 3,
   },
   {
     key: "core.flaresolverr_test",
@@ -42,7 +60,7 @@ export const CORE_SETTINGS: SettingDefinition[] = [
     description:
       "Sends a lightweight API call to FlareSolverr. Other settings are saved first; the URL field value above is used for the test.",
     defaultValue: false,
-    sortOrder: 3,
+    sortOrder: 4,
   },
   {
     key: "notifications.ntfy_url",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,6 +6,8 @@ export interface FileEntry {
   isDirectory: boolean;
   size: number;
   modifiedAt: string;
+  isNsfw?: boolean;
+  isNsfwExplicit?: boolean;
 }
 
 export interface SettingData {


### PR DESCRIPTION
## Summary
- Add NSFW metadata persistence for archived files, including database migration and metadata reconciliation for file operations.
- Add NSFW visibility settings and API support to mark/unmark files as NSFW.
- Update the file browser UI with NSFW badges, blur/show behavior, and bulk selection toolbar actions.

## Tests
- `npm run build` (reported passing by Codex worker)
- `git diff --check` (reported passing by Codex worker)
- Review image built successfully as `archiver-dev:APP-5`
- Internal container-local HTTP probe against the review deployment returned 200 OK

## Risks / unrun tests
- No additional automated browser test suite was run by Hermes in this cron pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NSFW file marking with three visibility modes: Off (server-hides content), Blur (visual obscuring), and Show (fully visible)
  * Ability to mark and unmark individual files or bulk-selected files as NSFW from the file browser
  * NSFW items display badges and apply blur effects based on the selected mode
  * NSFW metadata persists through file operations including move, copy, rename, and delete

<!-- end of auto-generated comment: release notes by coderabbit.ai -->